### PR TITLE
Add installing information to the README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+clean:
+	rm -rf build dist
+	find . -name '*.pyc' -exec rm \{\} \;
+
+test:
+	openfisca-run-test openfisca_extension_template --country_package openfisca_country_template --extensions openfisca_extension_template

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# openfisca-extension-template
-Template to build extensions to Openfisca-France
+# OpenFisca Extension-Template
+
+This repository is here to help you quickly bootstrap and use your own OpenFisca [extension](https://doc.openfisca.fr/contribute/extensions.html) package.
+
+## Bootstrapping an extension package
+
+This is similar to bootstrapping a country package. See country package bootstrapping instructions in this [README](https://github.com/openfisca/country-template#bootstrapping-a-country-package).
+
+## Installing
+
+This is similar to installing a country package. See country package installation instructions this [README](https://github.com/openfisca/country-template#installing).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,39 @@
 # OpenFisca Extension-Template
 
-This repository is here to help you quickly bootstrap and use your own OpenFisca [extension](https://doc.openfisca.fr/contribute/extensions.html) package.
-
-## Bootstrapping an extension package
-
-This is similar to bootstrapping a country package. See country package bootstrapping instructions in this [README](https://github.com/openfisca/country-template#bootstrapping-a-country-package).
+This repository is here to help you install your own OpenFisca [extension](https://doc.openfisca.fr/contribute/extensions.html) package.
 
 ## Installing
 
-This is similar to installing a country package. See country package installation instructions this [README](https://github.com/openfisca/country-template#installing).
+> We assume that you have already installed your own OpenFisca country package. If you don't have such a package in your environment, see OpenFisca [documentation](https://doc.openfisca.fr/coding-the-legislation/bootstrapping_a_new_country_package.html) for more information.
+
+> We recommend that you [use a virtualenv](https://doc.openfisca.fr/for_developers.html#create-a-virtualenv) to install OpenFisca. If you don't, you may need to add `--user` at the end of all commands starting by `pip`.
+
+To install your extension, go to the directory where you want to install it. Then, follow these steps:
+1. Download this template code and move into its directory: 
+
+```
+git clone https://github.com/openfisca/openfisca-extension-template.git
+cd openfisca-extension-template
+```
+
+2. Look for the name of your country package:
+* If you are using `openfisca_country_template`, you are all set. Follow the next step.
+* If you want to use a specific country package, open the [Makefile](./Makefile) and replace `openfisca_country_template` by your country package name in:
+
+  `openfisca-run-test openfisca_extension_template --country_package `**`openfisca_country_template`**` --extensions openfisca_extension_template`
+
+3. Run:
+
+```
+pip install -e ".[test]"
+```
+
+You can make sure that everything is working by running the provided tests:
+
+```sh
+make test
+```
+
+> [Learn more about tests](https://doc.openfisca.fr/coding-the-legislation/writing_yaml_tests.html).
+
+Your extension package is now installed and ready!

--- a/README.md
+++ b/README.md
@@ -1,32 +1,18 @@
 # OpenFisca Extension-Template
 
-This repository is here to help you install your own OpenFisca [extension](https://doc.openfisca.fr/contribute/extensions.html) package.
+This repository is here to help you bootstrap your own OpenFisca [extension](https://doc.openfisca.fr/contribute/extensions.html) package.
 
 ## Installing
 
-> We assume that you have already installed your own OpenFisca country package. If you don't have such a package in your environment, see OpenFisca [documentation](https://doc.openfisca.fr/coding-the-legislation/bootstrapping_a_new_country_package.html) for more information.
+> We recommend that you [use a virtualenv](https://github.com/openfisca/country-template/blob/master/README.md#setting-up-a-virtual-environment-with-pew) to install OpenFisca. If you don't, you may need to add `--user` at the end of all commands starting by `pip`.
 
-> We recommend that you [use a virtualenv](https://doc.openfisca.fr/for_developers.html#create-a-virtualenv) to install OpenFisca. If you don't, you may need to add `--user` at the end of all commands starting by `pip`.
+To install your extension, run:
 
-To install your extension, go to the directory where you want to install it. Then, follow these steps:
-1. Download this template code and move into its directory: 
-
-```
-git clone https://github.com/openfisca/openfisca-extension-template.git
-cd openfisca-extension-template
+```sh
+pip install --editable ".[test]"  # must be executed from the directory containing the setup.py file
 ```
 
-2. Look for the name of your country package:
-* If you are using `openfisca_country_template`, you are all set. Follow the next step.
-* If you want to use a specific country package, open the [Makefile](./Makefile) and replace `openfisca_country_template` by your country package name in:
-
-  `openfisca-run-test openfisca_extension_template --country_package `**`openfisca_country_template`**` --extensions openfisca_extension_template`
-
-3. Run:
-
-```
-pip install -e ".[test]"
-```
+## Testing
 
 You can make sure that everything is working by running the provided tests:
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,9 @@ setup(
     author="",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=[],
+    install_requires = [
+        'OpenFisca-Country-Template >= 1.2.0,  < 2.0',
+        ],
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,11 @@ setup(
     install_requires = [
         'OpenFisca-Country-Template >= 1.2.0,  < 2.0',
         ],
+    extras_require = {
+        'test': [
+            'nose',
+            ]
+        },
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",


### PR DESCRIPTION
Connected to openfisca/openfisca-core#464

In order to improve the documentation and ImportError messages in Core when an extension template is involved, adds bootstrapping and installing section in the README.